### PR TITLE
Update scoring to penalize path segments

### DIFF
--- a/api.py
+++ b/api.py
@@ -124,6 +124,7 @@ def annotate_fun_weights(G):
         'cycleway': 1.5,    # A small bonus for cycleways
         'steps': 0.9,       # Slight penalty for steps
     }
+    path_penalty_factor = 3.0  # Heavily penalize generic 'path' ways
     # Penalties are divisors for major roads
     highway_penalties = {
         'primary': 3.0,
@@ -157,7 +158,10 @@ def annotate_fun_weights(G):
 
         # Final fun_weight is length divided by the fun score
         # A higher score means a lower weight, making it more likely to be chosen
-        data['fun_weight'] = data['length'] / max(base_score, 0.1)
+        weight = data['length'] / max(base_score, 0.1)
+        if 'path' in hws:
+            weight *= path_penalty_factor
+        data['fun_weight'] = weight
 
     elapsed = time.time() - start_time
     print(f"[{datetime.now().strftime('%H:%M:%S')}] Fun weights calculated in {elapsed:.2f}s")

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ def annotate_fun_weights(G):
     start_time = time.time()
     
     fun_highways = {'footway','path','pedestrian','track','steps','cycleway'}
+    path_penalty_factor = 3.0  # Heavily penalize generic 'path' ways
     fun_edges = 0
     park_edges = 0
     attraction_edges = 0
@@ -46,10 +47,13 @@ def annotate_fun_weights(G):
         if data.get('leisure')=='park':      
             score += 1.5
             park_edges += 1
-        if data.get('tourism') in ('viewpoint','attraction'): 
+        if data.get('tourism') in ('viewpoint','attraction'):
             score += 3.0
             attraction_edges += 1
-        data['fun_weight'] = data['length'] / score
+        weight = data['length'] / score
+        if hw == 'path':
+            weight *= path_penalty_factor
+        data['fun_weight'] = weight
     
     elapsed = time.time() - start_time
     print(f"[{datetime.now().strftime('%H:%M:%S')}] Fun weights calculated in {elapsed:.2f}s")


### PR DESCRIPTION
## Summary
- discourage usage of generic `path` ways by adding a penalty factor
- apply the penalty in both the CLI and API scoring functions

## Testing
- `python3 -m py_compile main.py api.py`


------
https://chatgpt.com/codex/tasks/task_e_6885ef41a1d083338a0ffb05854bbd5a